### PR TITLE
refactor: Remove unused TODOIST_TASKS_COMPLETED counter from exporter.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ The exporter provides the following metrics:
 | `todoist_tasks_total` | Total number of active tasks | project_name, project_id |
 | `todoist_tasks_overdue` | Number of overdue tasks | project_name, project_id |
 | `todoist_tasks_due_today` | Number of tasks due today | project_name, project_id |
-| `todoist_tasks_completed` | Number of completed tasks (counter) | project_name, project_id |
 | `todoist_project_collaborators` | Number of collaborators per project | project_name, project_id |
 | `todoist_sections_total` | Number of sections per project | project_name, project_id |
 | `todoist_comments_total` | Number of comments | project_name, project_id |
@@ -423,8 +422,7 @@ To enable these workflows, ensure the following secrets are set in your reposito
      ```bash
      cp .env.example .env  # Add your Todoist API token
      task setup-dev  # Install dependencies
-     ```
-   - Make code changes and test locally with:
+     ```   - Make code changes and test locally with:
      ```bash
      source .env && task run
      ```

--- a/prometheus_todoist_exporter/exporter.py
+++ b/prometheus_todoist_exporter/exporter.py
@@ -33,11 +33,6 @@ TODOIST_TASKS_DUE_TODAY = Gauge(
     "Number of tasks due today",
     ["project_name", "project_id"],
 )
-TODOIST_TASKS_COMPLETED = Counter(
-    "todoist_tasks_completed",
-    "Number of completed tasks",
-    ["project_name", "project_id"],
-)
 TODOIST_PROJECT_COLLABORATORS = Gauge(
     "todoist_project_collaborators",
     "Number of collaborators per project",

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -35,7 +35,6 @@ class TestTodoistExporter(unittest.TestCase):
         self.tasks_total = exporter.TODOIST_TASKS_TOTAL
         self.tasks_overdue = exporter.TODOIST_TASKS_OVERDUE
         self.tasks_due_today = exporter.TODOIST_TASKS_DUE_TODAY
-        self.tasks_completed = exporter.TODOIST_TASKS_COMPLETED
         self.project_collaborators = exporter.TODOIST_PROJECT_COLLABORATORS
         self.sections_total = exporter.TODOIST_SECTIONS_TOTAL
         self.comments_total = exporter.TODOIST_COMMENTS_TOTAL


### PR DESCRIPTION
- Deleted the TODOIST_TASKS_COMPLETED counter as it was no longer needed in the exporter logic, simplifying the codebase.